### PR TITLE
Avoid using log10 to initialise static data

### DIFF
--- a/src/interp_support.f90
+++ b/src/interp_support.f90
@@ -15,7 +15,7 @@ module interp_support
   real(dp), parameter :: Y_proto=2.703d-1
   real(dp), parameter :: X_proto=7.155d-1
   real(dp), parameter :: Y_BBN=2.49d-1
-  real(dp), parameter :: Z_div_X_proto=log10(Z_proto/X_proto)
+  real(dp), parameter :: Z_div_X_proto=-1.7023212937127388 !log10(Z_proto/X_proto)
   real(dp), parameter :: dY_dZ = (Y_proto-Y_BBN)/Z_proto
 
 contains

--- a/src/iso_eep_color.f90
+++ b/src/iso_eep_color.f90
@@ -14,7 +14,7 @@ module iso_eep_color
   real(sp), parameter :: SolBol=4.74
   real(sp), parameter :: Z_sol = 0.0134, Xsol = 0.7381
   real(sp), parameter :: Z_div_X_sol = 0.0181
-  real(sp), parameter :: log_Z_sol = log10(Z_sol)
+  real(sp), parameter :: log_Z_sol = -1.8728952016351923 ! log10(Z_sol)
   real(sp) :: BC_Fe_div_H
   type(BC_table), allocatable :: b(:)
   logical ::do_fixed_Z = .false.


### PR DESCRIPTION
This seems unsupported by Fortran (at least 95), and is causing segfaults in gfortran 11 through 14. Compilers shouldn't segfault, even on the face of allegedly invalid code, but let's avoid the issue altogether.

This fixes #13 locally.